### PR TITLE
Have unreleased Garden Linux 1592.5 in db so we can add cve context for it

### DIFF
--- a/Containerfile.apt-source
+++ b/Containerfile.apt-source
@@ -1,4 +1,4 @@
-FROM ghcr.io/gardenlinux/gardenlinux:1592.3
+FROM ghcr.io/gardenlinux/gardenlinux:1592.4
 
 RUN apt-get update && apt-get install -y lz4
 

--- a/Containerfile.debug
+++ b/Containerfile.debug
@@ -1,0 +1,11 @@
+FROM docker.io/library/debian:trixie-slim
+
+# XXX: Debian unstable required for python3-sqlalchemy (>= 2)
+RUN sed -i -e 's/Suites: trixie trixie-updates/\0 unstable/' /etc/apt/sources.list.d/debian.sources
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends python3-asyncpg python3-pip python3-poetry-core python3-requests python3-sqlalchemy/unstable && \
+    apt-get upgrade -y --no-install-recommends git curl debian-archive-keyring postgresql-client && \
+    apt-get upgrade -y --no-install-recommends vim
+COPY . /usr/local/src
+COPY keyring.asc /etc/apt/trusted.gpg.d/keyring.asc
+RUN pip install --break-system-packages --no-deps --editable /usr/local/src

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,45 @@
+# Debug setup, not used in production
+
+services:
+  glvd-postgres:
+    image: ghcr.io/gardenlinux/glvd-postgres:latest
+    hostname: glvd-postgres
+    networks:
+      - glvd_ingest
+    volumes:
+      - glvd_db_ingest_volume:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: glvd
+      POSTGRES_DB: glvd
+      POSTGRES_PASSWORD: glvd
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U glvd -d glvd"]
+      interval: 10s
+      retries: 10
+      start_period: 30s
+      timeout: 10s
+
+  ingest:
+    build:
+      dockerfile: Containerfile.debug
+    networks:
+      - glvd_ingest
+    depends_on:
+      glvd-postgres:
+        condition: service_healthy
+        restart: false
+    environment:
+      PGHOST: glvd-postgres
+      PGPORT: 5432
+      PGDATABASE: glvd
+      PGUSER: glvd
+      PGPASSWORD: glvd
+    command: "sleep infinity"
+
+networks:
+  glvd_ingest: {}
+
+volumes:
+  glvd_db_ingest_volume:

--- a/ingest-postgres.sh
+++ b/ingest-postgres.sh
@@ -40,9 +40,13 @@ python3 -m glvd.cli.data.ingest_debsec debian security-tracker/data
 echo "Run data ingestion (ingest-debsrc - gardenlinux today)"
 python3 -m glvd.cli.data.ingest_debsrc gardenlinux today /usr/local/src/data/ingest-debsrc/gardenlinux/lists/packages.gardenlinux.io_gardenlinux_dists_today_main_source_Sources
 
-echo "Run data ingestion (ingest-debsrc - gardenlinux 1592)"
-python3 -m glvd.cli.data.ingest_debsrc gardenlinux 1592 /usr/local/src/data/ingest-debsrc/gardenlinux/lists/packages.gardenlinux.io_gardenlinux_dists_1592.4_main_source_Sources
+echo "Run data ingestion (ingest-debsrc - gardenlinux 1592.4)"
+python3 -m glvd.cli.data.ingest_debsrc gardenlinux 1592.4 /usr/local/src/data/ingest-debsrc/gardenlinux/lists/packages.gardenlinux.io_gardenlinux_dists_1592.4_main_source_Sources
 
+# Import with empty file as 1592.5 is not released yet -- not sure if there is an better option to do that
+EMPTY_FILE=$(mktemp)
+echo "Run data ingestion (ingest-debsrc - gardenlinux 1592.5)"
+python3 -m glvd.cli.data.ingest_debsrc gardenlinux 1592.5 "$EMPTY_FILE"
 
 echo "Run data ingestion (nvd)"
 echo date before nvd

--- a/src/glvd/cli/data/ingest_debsec.py
+++ b/src/glvd/cli/data/ingest_debsec.py
@@ -83,7 +83,7 @@ class IngestDebsec:
                 await session.delete(entry)
                 continue
 
-            # Update object in place. Only real changes will be commited
+            # Update object in place. Only real changes will be committed
             entry.merge(new_entry)
 
     async def import_cve_insert(

--- a/src/glvd/cli/data/ingest_debsrc.py
+++ b/src/glvd/cli/data/ingest_debsrc.py
@@ -85,7 +85,7 @@ class IngestDebsrc:
                 await session.delete(entry)
                 continue
 
-            # Update object in place. Only real changes will be commited
+            # Update object in place. Only real changes will be committed
             entry.merge(new_entry)
 
     async def import_insert(

--- a/src/glvd/data/dist_cpe.py
+++ b/src/glvd/data/dist_cpe.py
@@ -65,7 +65,7 @@ class DistCpeMapperGardenlinux(DistCpeMapper):
     def __call__(self, codename: str) -> DistCpe:
         version: str = {
             '1592.4': '1592.4',
-            '1592': '1592.5',
+            '1592.5': '1592.5',
             'today': 'today',
             '': '',
         }[codename]

--- a/src/prepare_ingestion.sh
+++ b/src/prepare_ingestion.sh
@@ -3,22 +3,30 @@
 set -e
 
 # Install Debian Keyring
-sudo apt update
-sudo apt install -y debian-archive-keyring
+apt-get update
+apt-get install -y debian-archive-keyring
 
-# Prepare: mount directories
-mkdir -p tmp/ingest-debsec/{debian,gardenlinux}/CVE
-mkdir -p tmp/ingest-debsrc/debian
-mkdir -p tmp/ingest-debsrc/var/lib/dpkg
-touch tmp/ingest-debsrc/var/lib/dpkg/status
-
-# Prepare: ingest-debsec
+mkdir -p /usr/local/src/data/ingest-debsec/{debian,gardenlinux}/CVE
+mkdir -p /usr/local/src/data/ingest-debsec/debian/CVE
+mkdir -p /usr/local/src/data/ingest-debsrc/{debian,gardenlinux}
+mkdir -p /usr/local/src/data/ingest-debsrc/var/lib/dpkg
+touch /usr/local/src/data/ingest-debsrc/var/lib/dpkg/status
 curl https://salsa.debian.org/security-tracker-team/security-tracker/-/raw/master/data/CVE/list?ref_type=heads \
-    --output tmp/ingest-debsec/debian/CVE/list
-cp -p data/CVE/list tmp/ingest-debsec/gardenlinux/CVE/list
+    --output /usr/local/src/data/ingest-debsec/debian/CVE/list
+mkdir -p /usr/local/src/conf/ingest-debsrc/
 
-# Prepare: ingest-debsrc
-APT_CONFIG=conf/ingest-debsrc/apt.conf apt update \
-  -o Dir="$PWD/tmp/ingest-debsrc/" \
-  -o Dir::Etc::sourcelist="$PWD/conf/ingest-debsrc/debian.sources" \
-  -o Dir::State="$PWD/tmp/ingest-debsrc/"
+export APT_CONFIG=/usr/local/src/conf/ingest-debsrc/apt.conf 
+
+apt-get update \
+-o Dir="/usr/local/src/data/ingest-debsrc/debian/" \
+-o Dir::Etc::sourcelist="/usr/local/src/conf/ingest-debsrc/debian.sources" \
+-o Dir::State="/usr/local/src/data/ingest-debsrc/debian/"
+
+apt-get update \
+-o Dir="/usr/local/src/data/ingest-debsrc/gardenlinux/" \
+-o Dir::Etc::sourcelist="/usr/local/src/conf/ingest-debsrc/gardenlinux.sources" \
+-o Dir::State="/usr/local/src/data/ingest-debsrc/gardenlinux/"
+
+git clone --depth=1 https://salsa.debian.org/security-tracker-team/security-tracker
+
+find /usr/local/src/data -name '*source_Sources'


### PR DESCRIPTION
**What this PR does / why we need it**:
We want to be able to add CVE contexts for Garden Linux releases which are not released yet, i.e. to document which CVE will be fixed.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/glvd/issues/136
