### PR TITLE
Nvd exclusive CVE

### DIFF
--- a/extra-schema.sql
+++ b/extra-schema.sql
@@ -167,3 +167,22 @@ CREATE OR REPLACE VIEW public.cvedetails
 
 ALTER TABLE public.cvedetails
     OWNER TO glvd;
+
+
+-- View: public.nvd_exclusive_cve
+
+-- DROP VIEW public.nvd_exclusive_cve;
+
+CREATE OR REPLACE VIEW public.nvd_exclusive_cve
+ AS
+ SELECT nvd_cve.cve_id
+   FROM nvd_cve
+     LEFT JOIN all_cve ON nvd_cve.cve_id = all_cve.cve_id
+  WHERE all_cve.cve_id IS NULL
+  ORDER BY nvd_cve.cve_id DESC
+ LIMIT 500;
+
+ALTER TABLE public.nvd_exclusive_cve
+    OWNER TO glvd;
+
+

--- a/extra-schema.sql
+++ b/extra-schema.sql
@@ -138,11 +138,11 @@ ALTER TABLE public.sourcepackage
 
 CREATE OR REPLACE VIEW public.cvedetails
  AS
- SELECT all_cve.cve_id AS cve_id,
-    all_cve.data -> 'vulnStatus'::text AS vulnstatus,
-    all_cve.data -> 'published'::text AS published,
-    all_cve.data -> 'lastModified'::text AS modified,
-    all_cve.last_mod AS ingested,
+ SELECT nvd_cve.cve_id AS cve_id,
+    nvd_cve.data -> 'vulnStatus'::text AS vulnstatus,
+    nvd_cve.data -> 'published'::text AS published,
+    nvd_cve.data -> 'lastModified'::text AS modified,
+    nvd_cve.last_mod AS ingested,
     array_agg(cve_context.description) AS cve_context_description,
     array_agg(dist_cpe.cpe_product) AS distro,
     array_agg(dist_cpe.cpe_version) AS distro_version,
@@ -150,20 +150,20 @@ CREATE OR REPLACE VIEW public.cvedetails
     array_agg(deb_cve.deb_source) AS source_package_name,
     array_agg(deb_cve.deb_version::text) AS source_package_version,
     array_agg(deb_cve.deb_version_fixed::text) AS version_fixed,
-    ((all_cve.data -> 'descriptions'::text) -> 0) -> 'value'::text AS description,
-    (((((all_cve.data -> 'metrics'::text) -> 'cvssMetricV40'::text) -> 0) -> 'cvssData'::text) ->> 'baseScore'::text)::numeric AS base_score_v40,
-    (((((all_cve.data -> 'metrics'::text) -> 'cvssMetricV31'::text) -> 0) -> 'cvssData'::text) ->> 'baseScore'::text)::numeric AS base_score_v31,
-    (((((all_cve.data -> 'metrics'::text) -> 'cvssMetricV30'::text) -> 0) -> 'cvssData'::text) ->> 'baseScore'::text)::numeric AS base_score_v30,
-    (((((all_cve.data -> 'metrics'::text) -> 'cvssMetricV2'::text) -> 0) -> 'cvssData'::text) ->> 'baseScore'::text)::numeric AS base_score_v2,
-    ((((all_cve.data -> 'metrics'::text) -> 'cvssMetricV40'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text AS vector_string_v40,
-    ((((all_cve.data -> 'metrics'::text) -> 'cvssMetricV31'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text AS vector_string_v31,
-    ((((all_cve.data -> 'metrics'::text) -> 'cvssMetricV30'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text AS vector_string_v30,
-    ((((all_cve.data -> 'metrics'::text) -> 'cvssMetricV2'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text AS vector_string_v2
-   FROM all_cve
+    ((nvd_cve.data -> 'descriptions'::text) -> 0) -> 'value'::text AS description,
+    (((((nvd_cve.data -> 'metrics'::text) -> 'cvssMetricV40'::text) -> 0) -> 'cvssData'::text) ->> 'baseScore'::text)::numeric AS base_score_v40,
+    (((((nvd_cve.data -> 'metrics'::text) -> 'cvssMetricV31'::text) -> 0) -> 'cvssData'::text) ->> 'baseScore'::text)::numeric AS base_score_v31,
+    (((((nvd_cve.data -> 'metrics'::text) -> 'cvssMetricV30'::text) -> 0) -> 'cvssData'::text) ->> 'baseScore'::text)::numeric AS base_score_v30,
+    (((((nvd_cve.data -> 'metrics'::text) -> 'cvssMetricV2'::text) -> 0) -> 'cvssData'::text) ->> 'baseScore'::text)::numeric AS base_score_v2,
+    ((((nvd_cve.data -> 'metrics'::text) -> 'cvssMetricV40'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text AS vector_string_v40,
+    ((((nvd_cve.data -> 'metrics'::text) -> 'cvssMetricV31'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text AS vector_string_v31,
+    ((((nvd_cve.data -> 'metrics'::text) -> 'cvssMetricV30'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text AS vector_string_v30,
+    ((((nvd_cve.data -> 'metrics'::text) -> 'cvssMetricV2'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text AS vector_string_v2
+   FROM nvd_cve
      JOIN deb_cve USING (cve_id)
      JOIN dist_cpe ON deb_cve.dist_id = dist_cpe.id
      FULL JOIN cve_context USING (cve_id, dist_id)
-  GROUP BY all_cve.cve_id;
+  GROUP BY nvd_cve.cve_id;
 
 ALTER TABLE public.cvedetails
     OWNER TO glvd;
@@ -175,7 +175,7 @@ ALTER TABLE public.cvedetails
 
 CREATE OR REPLACE VIEW public.nvd_exclusive_cve
  AS
- SELECT nvd_cve.cve_id
+ SELECT nvd_cve.cve_id, nvd_cve.data
    FROM nvd_cve
      LEFT JOIN all_cve ON nvd_cve.cve_id = all_cve.cve_id
   WHERE all_cve.cve_id IS NULL
@@ -185,4 +185,20 @@ CREATE OR REPLACE VIEW public.nvd_exclusive_cve
 ALTER TABLE public.nvd_exclusive_cve
     OWNER TO glvd;
 
+-- View: public.nvd_exclusive_cve_matching_gl
 
+-- DROP VIEW public.nvd_exclusive_cve_matching_gl;
+
+CREATE OR REPLACE VIEW public.nvd_exclusive_cve_matching_gl
+ AS
+ SELECT nvd_exclusive_cve.cve_id,
+    ((nvd_exclusive_cve.data -> 'descriptions'::text) -> 0) -> 'value'::text AS description
+   FROM nvd_exclusive_cve
+     JOIN ( SELECT debsrc.deb_source
+           FROM debsrc
+          WHERE debsrc.dist_id = 15) filtered_debsrc ON (EXISTS ( SELECT 1
+           FROM jsonb_array_elements(nvd_exclusive_cve.data::jsonb -> 'descriptions'::text) description(value)
+          WHERE (description.value ->> 'lang'::text) = 'en'::text AND (description.value ->> 'value'::text) ~~* (('%'::text || filtered_debsrc.deb_source) || '%'::text)));
+
+ALTER TABLE public.nvd_exclusive_cve_matching_gl
+    OWNER TO glvd;


### PR DESCRIPTION
Allow viewing CVEs which are only available in the nvd_cve table (i.e. they are not in the debian cve data)

Part of https://github.com/gardenlinux/glvd/issues/140