### PR TITLE
Ingest Kernel CVE information

### DIFF
--- a/Containerfile.debug
+++ b/Containerfile.debug
@@ -1,5 +1,17 @@
 FROM docker.io/library/debian:trixie-slim
 
+# Sample command to run inside the container:
+#   python3 -m glvd.cli.data
+#   python3 -m glvd.cli.data.ingest_kernel /vulns/cve/published/ --debug
+
+ENV PGUSER=glvd
+ENV PGDATABASE=glvd
+ENV PGPASSWORD=glvd
+ENV PGPORT=5432
+
+# You might want to override this variable depending on the hostname of your postgres container
+ENV PGHOST=glvd-postgres
+
 # XXX: Debian unstable required for python3-sqlalchemy (>= 2)
 RUN sed -i -e 's/Suites: trixie trixie-updates/\0 unstable/' /etc/apt/sources.list.d/debian.sources
 RUN apt-get update && \

--- a/extra-schema.sql
+++ b/extra-schema.sql
@@ -19,6 +19,21 @@ ALTER TABLE public.cve_context OWNER TO glvd;
 ALTER TABLE ONLY public.cve_context
     ADD CONSTRAINT cve_context_pkey PRIMARY KEY (dist_id, cve_id, create_date, context_descriptor);
 
+-- wip should be created via sqlalchemy
+-- --
+-- -- Name: cve_context_kernel; Type: TABLE; Schema: public; Owner: glvd
+-- --
+
+-- CREATE TABLE public.cve_context_kernel (
+--     cve_id text NOT NULL,
+--     lts_version text NOT NULL,
+--     fixed_version text,
+--     is_fixed boolean NOT NULL,
+--     is_relevant_module boolean NOT NULL,
+--     source_data jsonb NOT NULL
+-- );
+
+-- ALTER TABLE public.cve_context_kernel OWNER TO glvd;
 
 -- View: public.cve_with_context
 

--- a/extra-schema.sql
+++ b/extra-schema.sql
@@ -19,22 +19,6 @@ ALTER TABLE public.cve_context OWNER TO glvd;
 ALTER TABLE ONLY public.cve_context
     ADD CONSTRAINT cve_context_pkey PRIMARY KEY (dist_id, cve_id, create_date, context_descriptor);
 
--- wip should be created via sqlalchemy
--- --
--- -- Name: cve_context_kernel; Type: TABLE; Schema: public; Owner: glvd
--- --
-
--- CREATE TABLE public.cve_context_kernel (
---     cve_id text NOT NULL,
---     lts_version text NOT NULL,
---     fixed_version text,
---     is_fixed boolean NOT NULL,
---     is_relevant_module boolean NOT NULL,
---     source_data jsonb NOT NULL
--- );
-
--- ALTER TABLE public.cve_context_kernel OWNER TO glvd;
-
 -- View: public.cve_with_context
 
 -- DROP VIEW public.cve_with_context;

--- a/ingest-postgres.sh
+++ b/ingest-postgres.sh
@@ -27,6 +27,7 @@ apt-get update \
 -o Dir::State="/usr/local/src/data/ingest-debsrc/gardenlinux/"
 
 git clone --depth=1 https://salsa.debian.org/security-tracker-team/security-tracker
+git clone --depth=1 https://git.kernel.org/pub/scm/linux/security/vulns.git
 
 find /usr/local/src/data -name '*source_Sources'
 

--- a/ingest-postgres.sh
+++ b/ingest-postgres.sh
@@ -68,6 +68,8 @@ python3 -m glvd.cli.data.combine_deb
 echo "Run data combination (combine-all)"
 python3 -m glvd.cli.data.combine_all
 
+echo "Run kernel CVE ingestion"
+python3 -m glvd.cli.data.ingest_kernel vulns/cve/published/
 
 # taken from https://stackoverflow.com/a/20249534
 END=$(date +%s);

--- a/src/glvd/cli/data/__main__.py
+++ b/src/glvd/cli/data/__main__.py
@@ -11,6 +11,7 @@ from . import (  # noqa: F401
     ingest_debsec,
     ingest_debsrc,
     ingest_nvd,
+    ingest_kernel,
 )
 
 

--- a/src/glvd/cli/data/ingest_kernel.py
+++ b/src/glvd/cli/data/ingest_kernel.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from glvd.database import Base
+from . import cli
+
+
+logger = logging.getLogger(__name__)
+
+
+class IngestKernel:
+    @staticmethod
+    @cli.register(
+        'ingest-kernel',
+        arguments=[
+            cli.prepare_argument(
+                'dir',
+                help='data directory out of https://git.kernel.org/pub/scm/linux/security/vulns.git',
+                metavar='KERNEL_VULNS',
+                type=Path,
+            ),
+        ]
+    )
+    def run(*, argparser: None, dir: Path, database: str, debug: bool) -> None:
+        logging.basicConfig(level=debug and logging.DEBUG or logging.INFO)
+        engine = create_async_engine(database, echo=debug)
+        asyncio.run(IngestKernel(dir)(engine))
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def read(self) -> any:
+        # Implement the logic to read the kernel CVEs from the given path
+        pass
+
+    async def import_file(
+        self,
+        session: AsyncSession,
+    ) -> None:
+        file_cve = self.read()
+        # Implement the logic to process the file_cve
+
+    async def __call__(
+        self,
+        engine: AsyncEngine,
+    ) -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        async with async_sessionmaker(engine)() as session:
+            await self.import_file(session)
+            await session.commit()
+
+
+if __name__ == '__main__':
+    IngestKernel.run()

--- a/src/glvd/database/__init__.py
+++ b/src/glvd/database/__init__.py
@@ -14,7 +14,6 @@ from sqlalchemy import (
     Index,
     Column,
     Boolean,
-    JSONB,
 )
 from sqlalchemy.orm import (
     DeclarativeBase,
@@ -29,6 +28,8 @@ from sqlalchemy.types import (
     JSON,
     Text,
 )
+
+from sqlalchemy.dialects.postgresql import JSONB
 
 from ..data.cvss import CvssSeverity
 from .types import (

--- a/src/glvd/database/__init__.py
+++ b/src/glvd/database/__init__.py
@@ -12,6 +12,9 @@ from typing import (
 from sqlalchemy import (
     ForeignKey,
     Index,
+    Column,
+    Boolean,
+    JSONB,
 )
 from sqlalchemy.orm import (
     DeclarativeBase,
@@ -136,3 +139,13 @@ class AllCve(Base):
 
     def merge(self, other: Self) -> None:
         self.data = other.data
+
+class CveContextKernel(Base):
+    __tablename__ = 'cve_context_kernel'
+
+    cve_id = Column(Text, primary_key=True, nullable=False)
+    lts_version = Column(Text, primary_key=True, nullable=False)
+    fixed_version = Column(Text)
+    is_fixed = Column(Boolean, nullable=False)
+    is_relevant_module = Column(Boolean, nullable=False)
+    source_data = Column(JSONB, nullable=False)


### PR DESCRIPTION
We need special treatment for kernel CVE information because the data provided by NVD is not enough for us.
NVD does not maintain data on fixed CVEs in LTS kernels, but for us this is very relevant.
kernel.org provides data on that instead, so we need to take this into account additionally.

Part of the solution for https://github.com/gardenlinux/glvd/issues/122