### PR TITLE
[BREAKING] rename relevant_module to relevant_subsystem

### DIFF
--- a/src/glvd/cli/data/ingest_kernel.py
+++ b/src/glvd/cli/data/ingest_kernel.py
@@ -31,7 +31,7 @@ lts_versions = ["6.6", "6.12"]
 
 # List of irrelevant kernel submodules in the context of Garden Linux.
 # We still record CVEs related to those submodules, but we'll focus less on them.
-irrelevant_submodules = [
+irrelevant_subsystems = [
     "afs", "xen", "x86/hyperv", "wifi", "video/", "staging", "drm", "can", "Bluetooth", "mmc", "nfc", "thunderbolt",
     "s390", "riscv", "powerpc", "nouveau", "media", "leds", "usb", "MIPS", "nilfs2", "ubifs", "ocfs2", "spi", "i3c",
     "um", "udf", "atm", "eventfs", "fs/9p", "gtp", "hid", "i2c", "ice", "hwmon", "mailbox", "misc", "f2fs", "libfs",
@@ -58,9 +58,9 @@ def compare_versions(v1: str, v2: str) -> int:
     return 0
 
 
-def is_relevant_module(program_files: list[str]) -> bool:
+def is_relevant_subsystem(program_files: list[str]) -> bool:
     for file in program_files:
-        for submodule in irrelevant_submodules:
+        for submodule in irrelevant_subsystems:
             if submodule in file:
                 return False
     return True
@@ -142,7 +142,7 @@ class IngestKernel:
         program_files = []
         for entry in cve_data["containers"]["cna"]["affected"]:
             program_files.extend(entry.get("programFiles", []))
-        relevant_module = is_relevant_module(program_files)
+        relevant_subsystem = is_relevant_subsystem(program_files)
 
         # Get fixed versions for the specified LTS kernels
         fixed_versions = get_fixed_versions(lts_versions, cve_data)
@@ -162,7 +162,7 @@ class IngestKernel:
                     lts_version=lts,
                     fixed_version=version,
                     is_fixed=is_fixed,
-                    is_relevant_module=relevant_module,
+                    is_relevant_subsystem=relevant_subsystem,
                     source_data=contents,
                 )
                 .on_conflict_do_update(
@@ -170,7 +170,7 @@ class IngestKernel:
                     set_={
                         'fixed_version': version,
                         'is_fixed': is_fixed,
-                        'is_relevant_module': relevant_module,
+                        'is_relevant_subsystem': relevant_subsystem,
                         'source_data': contents,
                     }
                 )

--- a/src/glvd/cli/data/ingest_kernel.py
+++ b/src/glvd/cli/data/ingest_kernel.py
@@ -29,8 +29,8 @@ logger = logging.getLogger(__name__)
 # fixme(fwilhe): Get rid of the need for manual maintenance.
 lts_versions = ["6.6", "6.12"]
 
-# List of irrelevant kernel submodules in the context of Garden Linux.
-# We still record CVEs related to those submodules, but we'll focus less on them.
+# List of irrelevant kernel subsystems in the context of Garden Linux.
+# We still record CVEs related to those subsystems, but we'll focus less on them.
 irrelevant_subsystems = [
     "afs", "xen", "x86/hyperv", "wifi", "video/", "staging", "drm", "can", "Bluetooth", "mmc", "nfc", "thunderbolt",
     "s390", "riscv", "powerpc", "nouveau", "media", "leds", "usb", "MIPS", "nilfs2", "ubifs", "ocfs2", "spi", "i3c",

--- a/src/glvd/database/__init__.py
+++ b/src/glvd/database/__init__.py
@@ -148,5 +148,5 @@ class CveContextKernel(Base):
     lts_version = Column(Text, primary_key=True, nullable=False)
     fixed_version = Column(Text)
     is_fixed = Column(Boolean, nullable=False)
-    is_relevant_module = Column(Boolean, nullable=False)
+    is_relevant_subsystem = Column(Boolean, nullable=False)
     source_data = Column(JSONB, nullable=False)


### PR DESCRIPTION
"module" is not a good term, as kernel modules are something different. "subsystem" seems to be a better term for what we mean here, but this might also not be 100% accurate.

See also: https://docs.kernel.org/subsystem-apis.html