### PR TITLE
Add views to query kernel cves

### DIFF
--- a/extra-schema.sql
+++ b/extra-schema.sql
@@ -204,3 +204,74 @@ CREATE OR REPLACE VIEW public.nvd_exclusive_cve_matching_gl
 
 ALTER TABLE public.nvd_exclusive_cve_matching_gl
     OWNER TO glvd;
+
+-- View: public.kernel_vulns
+-- Not to be directly exposed to the user, used as abstraction for kernel_cve
+
+-- DROP VIEW public.kernel_vulns;
+
+CREATE OR REPLACE VIEW public.kernel_vulns
+ AS
+ SELECT all_cve.cve_id,
+    deb_cve.deb_source AS source_package_name,
+    deb_cve.deb_version AS source_package_version,
+    dist_cpe.cpe_version AS gardenlinux_version,
+    ((deb_cve.deb_version < cve_context_kernel.fixed_version::debversion OR cve_context_kernel.fixed_version IS NULL) AND cve_context_kernel.is_relevant_subsystem IS TRUE AND cve_context.is_resolved IS NOT TRUE) = true AS is_vulnerable,
+    cve_context_kernel.is_relevant_subsystem,
+    cve_context_kernel.lts_version,
+    cve_context_kernel.fixed_version::debversion AS fixed_version,
+    cve_context_kernel.is_fixed
+   FROM all_cve
+     JOIN deb_cve USING (cve_id)
+     JOIN dist_cpe ON deb_cve.dist_id = dist_cpe.id
+     FULL JOIN cve_context USING (cve_id, dist_id)
+     JOIN cve_context_kernel cve_context_kernel(cve_id_1, lts_version, fixed_version, is_fixed, is_relevant_subsystem, source_data) ON all_cve.cve_id = cve_context_kernel.cve_id_1 AND cve_context_kernel.lts_version = concat(split_part(deb_cve.deb_version::text, '.'::text, 1), '.', split_part(deb_cve.deb_version::text, '.'::text, 2))
+  WHERE dist_cpe.cpe_product = 'gardenlinux'::text AND ((deb_cve.deb_version < cve_context_kernel.fixed_version::debversion OR cve_context_kernel.fixed_version IS NULL) AND cve_context_kernel.is_relevant_subsystem IS TRUE AND cve_context.is_resolved IS NOT TRUE) = true AND deb_cve.deb_source = 'linux'::text;
+
+ALTER TABLE public.kernel_vulns
+    OWNER TO glvd;
+
+-- View: public.kernel_cve
+-- Kernel-specific counterpart for sourcepackagecve
+
+-- DROP VIEW public.kernel_cve;
+
+CREATE OR REPLACE VIEW public.kernel_cve
+ AS
+ SELECT k.cve_id,
+    k.source_package_name,
+    k.source_package_version,
+    k.gardenlinux_version,
+    k.is_vulnerable,
+    nvd.data ->> 'published'::text AS cve_published_date,
+    nvd.data ->> 'lastModified'::text AS cve_last_modified_date,
+    nvd.last_mod AS cve_last_ingested_date,
+        CASE
+            WHEN ((((((nvd.data -> 'metrics'::text) -> 'cvssMetricV31'::text) -> 0) -> 'cvssData'::text) ->> 'baseScore'::text)::numeric) IS NOT NULL THEN (((((nvd.data -> 'metrics'::text) -> 'cvssMetricV31'::text) -> 0) -> 'cvssData'::text) ->> 'baseScore'::text)::numeric
+            WHEN ((((((nvd.data -> 'metrics'::text) -> 'cvssMetricV30'::text) -> 0) -> 'cvssData'::text) ->> 'baseScore'::text)::numeric) IS NOT NULL THEN (((((nvd.data -> 'metrics'::text) -> 'cvssMetricV30'::text) -> 0) -> 'cvssData'::text) ->> 'baseScore'::text)::numeric
+            WHEN ((((((nvd.data -> 'metrics'::text) -> 'cvssMetricV2'::text) -> 0) -> 'cvssData'::text) ->> 'baseScore'::text)::numeric) IS NOT NULL THEN (((((nvd.data -> 'metrics'::text) -> 'cvssMetricV2'::text) -> 0) -> 'cvssData'::text) ->> 'baseScore'::text)::numeric
+            WHEN ((((((nvd.data -> 'metrics'::text) -> 'cvssMetricV40'::text) -> 0) -> 'cvssData'::text) ->> 'baseScore'::text)::numeric) IS NOT NULL THEN (((((nvd.data -> 'metrics'::text) -> 'cvssMetricV40'::text) -> 0) -> 'cvssData'::text) ->> 'baseScore'::text)::numeric
+            ELSE NULL::numeric
+        END AS base_score,
+        CASE
+            WHEN (((((nvd.data -> 'metrics'::text) -> 'cvssMetricV31'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text) IS NOT NULL THEN ((((nvd.data -> 'metrics'::text) -> 'cvssMetricV31'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text
+            WHEN (((((nvd.data -> 'metrics'::text) -> 'cvssMetricV30'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text) IS NOT NULL THEN ((((nvd.data -> 'metrics'::text) -> 'cvssMetricV30'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text
+            WHEN (((((nvd.data -> 'metrics'::text) -> 'cvssMetricV2'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text) IS NOT NULL THEN ((((nvd.data -> 'metrics'::text) -> 'cvssMetricV2'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text
+            WHEN (((((nvd.data -> 'metrics'::text) -> 'cvssMetricV40'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text) IS NOT NULL THEN ((((nvd.data -> 'metrics'::text) -> 'cvssMetricV40'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text
+            ELSE NULL::text
+        END AS vector_string,
+    (((((nvd.data -> 'metrics'::text) -> 'cvssMetricV40'::text) -> 0) -> 'cvssData'::text) ->> 'baseScore'::text)::numeric AS base_score_v40,
+    (((((nvd.data -> 'metrics'::text) -> 'cvssMetricV31'::text) -> 0) -> 'cvssData'::text) ->> 'baseScore'::text)::numeric AS base_score_v31,
+    (((((nvd.data -> 'metrics'::text) -> 'cvssMetricV30'::text) -> 0) -> 'cvssData'::text) ->> 'baseScore'::text)::numeric AS base_score_v30,
+    (((((nvd.data -> 'metrics'::text) -> 'cvssMetricV2'::text) -> 0) -> 'cvssData'::text) ->> 'baseScore'::text)::numeric AS base_score_v2,
+    ((((nvd.data -> 'metrics'::text) -> 'cvssMetricV40'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text AS vector_string_v40,
+    ((((nvd.data -> 'metrics'::text) -> 'cvssMetricV31'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text AS vector_string_v31,
+    ((((nvd.data -> 'metrics'::text) -> 'cvssMetricV30'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text AS vector_string_v30,
+    ((((nvd.data -> 'metrics'::text) -> 'cvssMetricV2'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text AS vector_string_v2
+   FROM kernel_vulns k
+     JOIN nvd_cve nvd USING (cve_id);
+
+ALTER TABLE public.kernel_cve
+    OWNER TO glvd;
+
+

--- a/extra-schema.sql
+++ b/extra-schema.sql
@@ -300,11 +300,11 @@ CREATE OR REPLACE VIEW public.cvedetails
     COALESCE(kc.vector_string_v30, ((((nvd_cve.data -> 'metrics'::text) -> 'cvssMetricV30'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text) AS vector_string_v30,
     COALESCE(kc.vector_string_v2, ((((nvd_cve.data -> 'metrics'::text) -> 'cvssMetricV2'::text) -> 0) -> 'cvssData'::text) ->> 'vectorString'::text) AS vector_string_v2
    FROM nvd_cve
-     JOIN deb_cve USING (cve_id)
+     JOIN deb_cve on deb_cve.cve_id = nvd_cve.cve_id and deb_cve.deb_source <> 'linux'
      JOIN dist_cpe ON deb_cve.dist_id = dist_cpe.id
      FULL JOIN cve_context USING (cve_id, dist_id)
-     LEFT JOIN kernel_cve kc ON kc.cve_id = nvd_cve.cve_id AND kc.source_package_name = 'linux' and kc.source_package_version like '6.6.%'
-  GROUP BY nvd_cve.cve_id, kc.base_score_v40, kc.base_score_v31, kc.base_score_v30, kc.base_score_v2, kc.vector_string_v40, kc.vector_string_v31, kc.vector_string_v30, kc.vector_string_v2;
+     FULL JOIN kernel_cve kc ON kc.cve_id = nvd_cve.cve_id AND kc.source_package_name = 'linux'
+  GROUP BY nvd_cve.cve_id, kc.cve_id, kc.base_score_v40, kc.base_score_v31, kc.base_score_v30, kc.base_score_v2, kc.vector_string_v40, kc.vector_string_v31, kc.vector_string_v30, kc.vector_string_v2;
 
 ALTER TABLE public.cvedetails
     OWNER TO glvd;


### PR DESCRIPTION
**What this PR does / why we need it**:

Add views to query kernel-specific cve information.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardenlinux/glvd/issues/122
