### PR TITLE
[BREAKING] Implement v1 of the triage format

### DIFF
--- a/schema/004-triage-data-v1.sql
+++ b/schema/004-triage-data-v1.sql
@@ -1,8 +1,7 @@
 SELECT
     assert_latest_migration (3);
 
-ALTER TABLE public.cve_context
-    RENAME COLUMN context_descriptor TO use_case;
+ALTER TABLE public.cve_context RENAME COLUMN context_descriptor TO use_case;
 
 ALTER TABLE public.cve_context
     ADD COLUMN triaged boolean DEFAULT FALSE;
@@ -12,3 +11,4 @@ ALTER TABLE public.cve_context
 
 SELECT
     log_migration (4);
+

--- a/schema/004-triage-data-v1.sql
+++ b/schema/004-triage-data-v1.sql
@@ -1,0 +1,14 @@
+SELECT
+    assert_latest_migration (3);
+
+ALTER TABLE public.cve_context
+    RENAME COLUMN context_descriptor TO use_case;
+
+ALTER TABLE public.cve_context
+    ADD COLUMN triaged boolean DEFAULT FALSE;
+
+ALTER TABLE public.cve_context
+    ALTER COLUMN is_resolved SET DEFAULT FALSE;
+
+SELECT
+    log_migration (4);


### PR DESCRIPTION
This is a breaking change to the `cve_context` table to implement version 1 of the triage format.

Part of https://github.com/gardenlinux/glvd/issues/157