### PR TITLE
Pin perl to 5.40.2 to make pgformatter happy

### DIFF
--- a/Containerfile.pg-formatter
+++ b/Containerfile.pg-formatter
@@ -1,4 +1,4 @@
-FROM perl:5.40-bookworm⁠
+FROM perl:5.41.13-bookworm
 
 COPY pgformatter.tgz /pgformatter.tgz
 RUN tar xf /pgformatter.tgz -C /

--- a/Containerfile.pg-formatter
+++ b/Containerfile.pg-formatter
@@ -1,4 +1,4 @@
-FROM perl:5.41.13-bookworm
+FROM perl:5.40.2-bookworm
 
 COPY pgformatter.tgz /pgformatter.tgz
 RUN tar xf /pgformatter.tgz -C /

--- a/Containerfile.pg-formatter
+++ b/Containerfile.pg-formatter
@@ -1,4 +1,4 @@
-FROM perl:bookworm
+FROM perl:5.40-bookworm⁠
 
 COPY pgformatter.tgz /pgformatter.tgz
 RUN tar xf /pgformatter.tgz -C /


### PR DESCRIPTION
pgformatter failed in ci recently, it seems to work with perl 5.40.2