### PR TITLE
Remove buster from the sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 This repository contains the code for gathering data needed by the Garden Linux Security Tracker [glvd](https://github.com/gardenlinux/glvd) to process vulnerability requests from users.
 
 Currently, data for the following distributions is collected:
-* Debian Buster
 * Debian Bulleye
 * Debian Bookworm
 * Debian Trixie

--- a/conf/ingest-debsrc/debian.sources
+++ b/conf/ingest-debsrc/debian.sources
@@ -1,6 +1,6 @@
 Enabled: yes
 Types: deb-src
 URIs: https://deb.debian.org/debian 
-Suites: buster bullseye bookworm trixie
+Suites: bullseye bookworm trixie
 Components: main 
 Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg


### PR DESCRIPTION
Debian buster is the previous oldstable release and trying to get apt update does not work anymore. Nothing is lost, buster was anyway only in there for historical reasons.

Resolves https://github.com/gardenlinux/glvd/issues/170
