### PR TITLE
Fix/using wrong wifi subsystem filter

### DIFF
--- a/src/glvd/cli/data/ingest_kernel.py
+++ b/src/glvd/cli/data/ingest_kernel.py
@@ -35,7 +35,7 @@ irrelevant_subsystems = [
     "afs",
     "xen",
     "x86/hyperv",
-    "wifi",
+    "drivers/net/wireless",
     "video/",
     "staging",
     "drm",
@@ -92,6 +92,7 @@ irrelevant_subsystems = [
     "sound",
     "drivers/soc/samsung",
     "drivers/hsi",
+    "marvell/cesa",
 ]
 
 


### PR DESCRIPTION
Based on the discussion on https://github.com/gardenlinux/glvd/issues/169 this will fix the Wi-Fi subfilter. Also adds one more irrelevant subsystem. 