### PR TITLE
Use debian sid images for now

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/debian:trixie-slim
+FROM docker.io/library/debian:sid-slim
 
 RUN apt-get update && \
     apt-get upgrade -y --no-install-recommends python3-asyncpg python3-pip python3-poetry-core python3-requests python3-sqlalchemy && \

--- a/Containerfile.debug
+++ b/Containerfile.debug
@@ -1,4 +1,4 @@
-FROM docker.io/library/debian:trixie-slim
+FROM docker.io/library/debian:sid-slim
 
 # Sample command to run inside the container:
 #   python3 -m glvd.cli.data

--- a/Containerfile.pg-init
+++ b/Containerfile.pg-init
@@ -1,4 +1,4 @@
-FROM docker.io/library/debian:trixie-slim
+FROM docker.io/library/debian:sid-slim
 
 ENV PGHOST glvd
 ENV PGPORT 5432

--- a/Containerfile.unit-tests
+++ b/Containerfile.unit-tests
@@ -1,4 +1,4 @@
-FROM docker.io/library/debian:trixie-slim
+FROM docker.io/library/debian:sid-slim
 
 RUN apt-get update && \
     apt-get upgrade -y --no-install-recommends python3-asyncpg python3-pip python3-poetry-core python3-requests python3-sqlalchemy && \


### PR DESCRIPTION
This is the only debian version that has postgres 18 right now

Follow up for https://github.com/gardenlinux/glvd/issues/179
