### PR TITLE
Postgres client from upstream apt repo

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,8 +1,31 @@
-FROM docker.io/library/debian:sid-slim
+FROM docker.io/library/debian:stable-slim
 
+# Install prerequisites and postgresql-common
 RUN apt-get update && \
-    apt-get upgrade -y --no-install-recommends python3-asyncpg python3-pip python3-poetry-core python3-requests python3-sqlalchemy && \
-    apt-get upgrade -y --no-install-recommends git curl debian-archive-keyring postgresql-client jq gettext-base
+    apt-get install -y --no-install-recommends \
+        curl \
+        ca-certificates \
+        postgresql-common \
+        python3-asyncpg \
+        python3-pip \
+        python3-poetry-core \
+        python3-requests \
+        python3-sqlalchemy \
+        git \
+        debian-archive-keyring \
+        jq \
+        gettext-base
+
+# Configure PostgreSQL upstream repository for client
+RUN install -d /usr/share/postgresql-common/pgdg && \
+    curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
+    . /etc/os-release && \
+    sh -c "echo 'deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $VERSION_CODENAME-pgdg main' > /etc/apt/sources.list.d/pgdg.list"
+
+# Install PostgreSQL client (replace 18 with desired version if needed)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends postgresql-client-18
+
 COPY . /usr/local/src
 COPY keyring.asc /etc/apt/trusted.gpg.d/keyring.asc
 RUN pip install --break-system-packages --no-deps --editable /usr/local/src

--- a/Containerfile
+++ b/Containerfile
@@ -1,11 +1,9 @@
 FROM docker.io/library/debian:stable-slim
 
-# Install prerequisites and postgresql-common
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         curl \
         ca-certificates \
-        postgresql-common \
         python3-asyncpg \
         python3-pip \
         python3-poetry-core \
@@ -16,13 +14,11 @@ RUN apt-get update && \
         jq \
         gettext-base
 
-# Configure PostgreSQL upstream repository for client
 RUN install -d /usr/share/postgresql-common/pgdg && \
     curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
     . /etc/os-release && \
     sh -c "echo 'deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $VERSION_CODENAME-pgdg main' > /etc/apt/sources.list.d/pgdg.list"
 
-# Install PostgreSQL client (replace 18 with desired version if needed)
 RUN apt-get update && \
     apt-get install -y --no-install-recommends postgresql-client-18
 

--- a/Containerfile.apt-source
+++ b/Containerfile.apt-source
@@ -1,4 +1,4 @@
-FROM ghcr.io/gardenlinux/gardenlinux:1592.7
+FROM ghcr.io/gardenlinux/gardenlinux:1877.4
 
 RUN apt-get update && apt-get install -y lz4
 

--- a/Containerfile.debug
+++ b/Containerfile.debug
@@ -1,4 +1,4 @@
-FROM docker.io/library/debian:sid-slim
+FROM docker.io/library/debian:stable-slim
 
 # Sample command to run inside the container:
 #   python3 -m glvd.cli.data
@@ -14,9 +14,28 @@ ENV PGPORT=5432
 ENV PGHOST=glvd-postgres
 
 RUN apt-get update && \
-    apt-get upgrade -y --no-install-recommends python3-asyncpg python3-pip python3-poetry-core python3-requests python3-sqlalchemy && \
-    apt-get upgrade -y --no-install-recommends git curl debian-archive-keyring postgresql-client  jq gettext-base && \
-    apt-get upgrade -y --no-install-recommends vim
+    apt-get install -y --no-install-recommends \
+        curl \
+        ca-certificates \
+        python3-asyncpg \
+        python3-pip \
+        python3-poetry-core \
+        python3-requests \
+        python3-sqlalchemy \
+        git \
+        debian-archive-keyring \
+        jq \
+        gettext-base \
+        vim
+
+RUN install -d /usr/share/postgresql-common/pgdg && \
+    curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
+    . /etc/os-release && \
+    sh -c "echo 'deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $VERSION_CODENAME-pgdg main' > /etc/apt/sources.list.d/pgdg.list"
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends postgresql-client-18
+
 COPY . /usr/local/src
 COPY keyring.asc /etc/apt/trusted.gpg.d/keyring.asc
 

--- a/Containerfile.pg-formatter
+++ b/Containerfile.pg-formatter
@@ -1,4 +1,4 @@
-FROM perl:5.40.2-bookworm
+FROM perl:5.40.3-trixie
 
 COPY pgformatter.tgz /pgformatter.tgz
 RUN tar xf /pgformatter.tgz -C /

--- a/Containerfile.pg-init
+++ b/Containerfile.pg-init
@@ -1,4 +1,4 @@
-FROM docker.io/library/debian:sid-slim
+FROM docker.io/library/debian:stable-slim
 
 ENV PGHOST glvd
 ENV PGPORT 5432
@@ -6,7 +6,18 @@ ENV PGDATABASE glvd
 ENV PGUSER glvd
 ENV PGPASSWORD glvd
 
-RUN apt-get update && apt-get install -y postgresql-client
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl \
+        ca-certificates
+
+RUN install -d /usr/share/postgresql-common/pgdg && \
+    curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
+    . /etc/os-release && \
+    sh -c "echo 'deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $VERSION_CODENAME-pgdg main' > /etc/apt/sources.list.d/pgdg.list"
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends postgresql-client-18
 
 COPY glvd.sql /glvd.sql
 COPY pg-init-entrypoint.sh /entrypoint.sh

--- a/Containerfile.unit-tests
+++ b/Containerfile.unit-tests
@@ -1,8 +1,27 @@
-FROM docker.io/library/debian:sid-slim
+FROM docker.io/library/debian:stable-slim
 
 RUN apt-get update && \
-    apt-get upgrade -y --no-install-recommends python3-asyncpg python3-pip python3-poetry-core python3-requests python3-sqlalchemy && \
-    apt-get upgrade -y --no-install-recommends git curl debian-archive-keyring postgresql-client jq gettext-base
+    apt-get install -y --no-install-recommends \
+        curl \
+        ca-certificates \
+        python3-asyncpg \
+        python3-pip \
+        python3-poetry-core \
+        python3-requests \
+        python3-sqlalchemy \
+        git \
+        debian-archive-keyring \
+        jq \
+        gettext-base
+
+RUN install -d /usr/share/postgresql-common/pgdg && \
+    curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
+    . /etc/os-release && \
+    sh -c "echo 'deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $VERSION_CODENAME-pgdg main' > /etc/apt/sources.list.d/pgdg.list"
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends postgresql-client-18
+
 COPY . /usr/local/src
 COPY keyring.asc /etc/apt/trusted.gpg.d/keyring.asc
 RUN pip install --break-system-packages --no-deps --editable /usr/local/src


### PR DESCRIPTION
We can't use postgres client from debian stable because that is not compatible with pg 18. Using testing or unstable is also not ideal. Using the upstream postgres apt repo allows us to be most up to date easily.