### PR TITLE
CI: Link get data step to the new make init image option

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,11 +80,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: |
+      - name: Get lastest data dump
+        if: ${{ inputs.create_init_image == true }}
+        run: |
           LATEST_RUN_ID=$(gh run list --repo gardenlinux/glvd-data-ingestion --status success --branch main --workflow 02-ingest-dump-snapshot.yaml --json databaseId --limit 1 | jq -r '.[0].databaseId')
           gh run download $LATEST_RUN_ID -n glvd.sql --repo gardenlinux/glvd-data-ingestion
         env:
           GH_TOKEN: ${{ github.token }}
+
       - name: Build Image (init image)
         if: ${{ inputs.create_init_image == true }}
         id: build_init_image


### PR DESCRIPTION
The release step to get the latest data dump can fail and make a release impossible. 
Hence, only download the last data dump, if we need it for the init image creation.